### PR TITLE
Fix typo in scss file for completed tasks

### DIFF
--- a/frontend/src/app/pages/task-view/task-view.component.scss
+++ b/frontend/src/app/pages/task-view/task-view.component.scss
@@ -80,7 +80,7 @@
 
     align-items: center;
     
-    &:not(.complete) {
+    &:not(.completed) {
         cursor: pointer;
         transition: box-shadow 0.2s ease, transform 0.2s ease;
     


### PR DESCRIPTION
Found a small typo in the scss file for the tasks. 'complete' changed to 'completed'. 